### PR TITLE
Do not require a authorized keys file for encryption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+sigtool
+
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a

--- a/crypt.go
+++ b/crypt.go
@@ -102,7 +102,7 @@ func encrypt(args []string) {
 	authkeys := fmt.Sprintf("%s/.ssh/authorized_keys", home)
 	authdata, err := ioutil.ReadFile(authkeys)
 	if err != nil {
-		if err != os.ErrNotExist {
+		if ! os.IsNotExist(err) {
 			die("can't open %s: %s", authkeys, err)
 		}
 	}


### PR DESCRIPTION
Without this change, I'm getting errors like these:

```
$ LANG=C ./sigtool encrypt ~/.ssh/uli-ed25519 -o /tmp/a /tmp/uli
./sigtool: can't open /home/uli/.ssh/authorized_keys: open /home/uli/.ssh/authorized_keys: no such file or directory
```

Please merge! ;)